### PR TITLE
Fixing build error on Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: fsharp
 sudo: false  # use the new container-based Travis infrastructure 
 
 script: 
-  - ./build.sh All
+  - sh ./build.sh All

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: fsharp
+language: csharp
 
 sudo: false  # use the new container-based Travis infrastructure 
 

--- a/src/ReactoKinesiX/Utils.fs
+++ b/src/ReactoKinesiX/Utils.fs
@@ -583,7 +583,7 @@ module internal DynamoDBUtils =
                         config.MaxDynamoDBRetries)
 
             return res 
-                   |> Result.Bind (fun res -> 
+                   |> InternalModel.Result.Bind (fun res -> 
                         getShardStatusInternal 
                             shardId 
                             config.HeartbeatTimeout 


### PR DESCRIPTION
When building with msbuild on Mac OS X, it tells me that there are multiple definitions of Result. Since Result is defined internally, the simplest solution is to reference the method more explicitly: `InternalModel.Result.Bind`